### PR TITLE
Fix a NullReferenceException in ExplorerBrowser by adjusting the order of static readonly fields.

### DIFF
--- a/source/WindowsAPICodePack/Shell/ExplorerBrowser/ExplorerBrowser.WPF.xaml.cs
+++ b/source/WindowsAPICodePack/Shell/ExplorerBrowser/ExplorerBrowser.WPF.xaml.cs
@@ -13,6 +13,24 @@ namespace Microsoft.WindowsAPICodePack.Controls.WindowsPresentationFoundation
     /// <summary>Interaction logic for ExplorerBrowser.xaml</summary>
     public partial class ExplorerBrowser : UserControl, IDisposable
     {
+        private static readonly DependencyPropertyKey ItemsPropertyKey =
+                    DependencyProperty.RegisterReadOnly(
+                        "Items", typeof(ObservableCollection<ShellObject>),
+                        typeof(ExplorerBrowser),
+                        new PropertyMetadata(null));
+
+        private static readonly DependencyPropertyKey NavigationLogPropertyKey =
+                    DependencyProperty.RegisterReadOnly(
+                        "NavigationLog", typeof(ObservableCollection<ShellObject>),
+                        typeof(ExplorerBrowser),
+                        new PropertyMetadata(null));
+
+        private static readonly DependencyPropertyKey SelectedItemsPropertyKey =
+                            DependencyProperty.RegisterReadOnly(
+                                "SelectedItems", typeof(ObservableCollection<ShellObject>),
+                                typeof(ExplorerBrowser),
+                                new PropertyMetadata(null));
+
         /// <summary>The items in the ExplorerBrowser window</summary>
         public static readonly DependencyProperty ItemsProperty = ItemsPropertyKey.DependencyProperty;
 
@@ -184,24 +202,6 @@ namespace Microsoft.WindowsAPICodePack.Controls.WindowsPresentationFoundation
                                 "ViewMode", typeof(ExplorerBrowserViewMode),
                                 typeof(ExplorerBrowser),
                                 new PropertyMetadata(ExplorerBrowserViewMode.Auto, OnViewModeChanged));
-
-        private static readonly DependencyPropertyKey ItemsPropertyKey =
-                            DependencyProperty.RegisterReadOnly(
-                                "Items", typeof(ObservableCollection<ShellObject>),
-                                typeof(ExplorerBrowser),
-                                new PropertyMetadata(null));
-
-        private static readonly DependencyPropertyKey NavigationLogPropertyKey =
-                            DependencyProperty.RegisterReadOnly(
-                                "NavigationLog", typeof(ObservableCollection<ShellObject>),
-                                typeof(ExplorerBrowser),
-                                new PropertyMetadata(null));
-
-        private static readonly DependencyPropertyKey SelectedItemsPropertyKey =
-                            DependencyProperty.RegisterReadOnly(
-                                "SelectedItems", typeof(ObservableCollection<ShellObject>),
-                                typeof(ExplorerBrowser),
-                                new PropertyMetadata(null));
 
         private readonly DispatcherTimer dtCLRUpdater = new DispatcherTimer();
 


### PR DESCRIPTION
Repro steps:
1. Open `.\source\Samples\ExplorerBrowser\CS\ExplorerBrowser.sln` in VS
2. Set `WPFExplorerBrowserDemo` as the startup project
3. Hit F5

Call stack:
```
System.NullReferenceException
  HResult=0x80004003
  Message=Object reference not set to an instance of an object.
  Source=Microsoft.WindowsAPICodePack.Shell
  StackTrace:
   at Microsoft.WindowsAPICodePack.Controls.WindowsPresentationFoundation.ExplorerBrowser..cctor()
 in D:\Playground\Windows-API-Code-Pack-1.1\source\WindowsAPICodePack\Shell\ExplorerBrowser\ExplorerBrowser.WPF.xaml.cs:line 17
```
